### PR TITLE
Add deployment context to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ gRPC server that supports
 [server reflection](https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1/reflection.proto).
 Schemas can also be imported from the [Buf Schema Registry](https://buf.build/).
 
-Requests are proxied through server-side API routes (browsers can't make native
-gRPC calls), so the app needs a Node.js backend -- it's not purely client-side.
+Requests proxy through Next.js API routes using `@grpc/grpc-js`. Deploys to
+Vercel as-is or self-host via Docker / Node.js.
 
 ## Features
 


### PR DESCRIPTION
One-liner noting Vercel/self-host deployment options.