### PR TITLE
fix: qualify gRPC endpoint failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Vercel as-is or self-host via Docker / Node.js.
 - Optional base64/binary response inspection that parses decoded JSON when
   present, while preserving original response JSON for copy and save actions
 - REST path mapping from `google.api.http` annotations
-- Round-robin endpoints, DNS validation, automatic blacklisting on failure,
-  TLS auto-retry
+- Round-robin endpoints, reflection-aware provider qualification, client-side
+  endpoint cooldowns, and automatic TLS retry
 - Search by namespace, service, or method
 - Client-side caching (configurable TTL, localStorage)
 - Execution history with timing
@@ -128,7 +128,7 @@ Browser (JSON)  -->  Next.js API Routes  -->  gRPC Server (protobuf/HTTP2)
 | `POST /api/grpc/services` | Service discovery via reflection |
 | `POST /api/grpc/execute` | RPC invocation |
 | `POST /api/grpc/descriptor` | Lazy-load service field definitions |
-| `POST /api/grpc/validate-endpoints` | DNS validation |
+| `POST /api/grpc/validate-endpoints` | DNS plus bounded gRPC reflection qualification |
 | `POST /api/grpc/test-compatibility` | Bulk method testing |
 | `GET /api/bsr/modules` | BSR module search |
 | `POST /api/bsr/descriptor` | Fetch FileDescriptorSet from BSR |
@@ -180,9 +180,11 @@ Private modules need an auth token.
 **Stale data**: Check cache TTL in settings, or clear via the menu bar cache
 indicator.
 
-**Unreachable endpoints**: DNS validation runs before connecting. If all
-endpoints fail, verify the server has outbound access to the gRPC ports
-(typically 9090, 443).
+**Unreachable endpoints**: Cosmos endpoint validation checks DNS and a bounded
+gRPC reflection handshake before selecting providers. A provider can resolve
+but still deny, omit, or time out on reflection; those endpoints are deselected
+but can be manually retried. If all endpoints fail, verify the server has
+outbound access to the gRPC ports (typically 9090, 443).
 
 ## License
 

--- a/app/api/grpc/execute/route.ts
+++ b/app/api/grpc/execute/route.ts
@@ -8,6 +8,9 @@ import { normalizeRequestTimeoutMs } from '@/lib/utils/client-cache';
 import { EndpointFailoverError, executeWithEndpointFailover, type ExecutionEndpoint } from '@/lib/utils/execution-endpoints';
 import { endpointManager } from '@/lib/utils/endpoint-manager';
 
+const MAX_ROUTE_EXECUTION_WINDOW_MS = 85_000;
+const REFLECTION_ATTEMPT_TIMEOUT_MS = 8_000;
+
 export const runtime = 'nodejs';
 export const maxDuration = 90; // 90 seconds to allow for 60s method timeout + overhead
 
@@ -17,6 +20,7 @@ export async function POST(req: Request) {
   try {
     const { endpoint, endpointAttempts, service, method, params, tlsEnabled, metadata, authConfig, timeoutMs } = await req.json();
     const requestTimeoutMs = normalizeRequestTimeoutMs(timeoutMs, 60000);
+    const deadlineAt = startTime + Math.min(MAX_ROUTE_EXECUTION_WINDOW_MS, requestTimeoutMs + 15_000);
 
     if (!endpoint || !service || !method) {
       return NextResponse.json(
@@ -41,7 +45,6 @@ export async function POST(req: Request) {
         .filter((attempt): attempt is ExecutionEndpoint =>
           typeof attempt?.address === 'string' && typeof attempt?.tlsEnabled === 'boolean'
         )
-        .slice(0, 3)
       : [];
     const attempts = configuredAttempts.length > 0
       ? configuredAttempts
@@ -64,6 +67,8 @@ export async function POST(req: Request) {
     }
 
     const execution = await executeWithEndpointFailover(attempts, async (attempt) => {
+      const remainingMs = deadlineAt - Date.now();
+      if (remainingMs <= 0) throw new Error('Execution deadline exhausted before endpoint attempt');
       let endpointWithPort = attempt.address;
       if (!endpointWithPort.includes(':')) {
         endpointWithPort = attempt.tlsEnabled ? `${endpointWithPort}:443` : `${endpointWithPort}:9090`;
@@ -71,17 +76,27 @@ export async function POST(req: Request) {
 
       console.log(`[Execute] Invoking ${service}.${method} on ${endpointWithPort} (TLS: ${attempt.tlsEnabled})`);
       const invoke = async (usedTls: boolean) => {
+        const invokeRemainingMs = deadlineAt - Date.now();
+        if (invokeRemainingMs <= 0) throw new Error('Execution deadline exhausted before reflection initialization');
         const client = new ReflectionClient({
           endpoint: endpointWithPort,
           tls: usedTls,
-          timeout: requestTimeoutMs,
+          timeout: Math.min(REFLECTION_ATTEMPT_TIMEOUT_MS, invokeRemainingMs),
           clientCert,
           clientKey,
         });
 
         try {
-          await client.initializeForMethod(service);
-          return await client.invokeMethod(service, method, params || {}, requestTimeoutMs, enrichedMetadata);
+          try {
+            await client.initializeForMethod(service);
+          } catch (error) {
+            throw new Error(`Reflection initialization failed: ${errorMessage(error)}`);
+          }
+          try {
+            return await client.invokeMethod(service, method, params || {}, Math.min(requestTimeoutMs, Math.max(1, deadlineAt - Date.now())), enrichedMetadata);
+          } catch (error) {
+            throw new Error(`Method invocation failed: ${errorMessage(error)}`);
+          }
         } finally {
           client.close();
         }
@@ -113,6 +128,11 @@ export async function POST(req: Request) {
         endpointManager.recordFailure(endpointWithPort, msg.includes('timeout') || msg.includes('ETIMEDOUT'));
         throw err;
       }
+    }, {
+      deadlineAt,
+      // Retrying a completed method invocation can duplicate stateful RPCs.
+      // Only reflection setup is safe to replay at another provider.
+      shouldFailover: (error) => errorMessage(error).includes('Reflection initialization failed:'),
     });
 
     const executionTime = Date.now() - startTime;

--- a/app/api/grpc/validate-endpoints/route.ts
+++ b/app/api/grpc/validate-endpoints/route.ts
@@ -1,13 +1,26 @@
 import { NextResponse } from 'next/server';
 import dns from 'dns';
 import { promisify } from 'util';
+import { ReflectionClient } from '@/lib/grpc/reflection-client';
+import { errorMessage } from '@/lib/utils';
+import { classifyReflectionFailure } from '@/lib/utils/reflection-probe';
 
 const dnsLookup = promisify(dns.lookup);
+const MAX_QUALIFIED_ENDPOINTS = 30;
+
+export const runtime = 'nodejs';
+export const maxDuration = 45;
 
 interface EndpointValidation {
 	address: string;
 	reachable: boolean;
 	error?: string;
+	reflectionStatus?: 'ready' | 'incompatible' | 'transient';
+}
+
+interface EndpointInput {
+	address: string;
+	tlsEnabled?: boolean;
 }
 
 /**
@@ -31,7 +44,8 @@ function extractHostname(address: string): string {
  * Validates a single endpoint by attempting DNS resolution
  * Uses a fast 1 second timeout to quickly identify unreachable endpoints
  */
-async function validateEndpoint(address: string, timeoutMs: number = 1000): Promise<EndpointValidation> {
+async function validateEndpoint(input: EndpointInput, timeoutMs: number = 1000): Promise<EndpointValidation> {
+	const { address } = input;
 	const hostname = extractHostname(address);
 
 	if (!hostname) {
@@ -50,16 +64,35 @@ async function validateEndpoint(address: string, timeoutMs: number = 1000): Prom
 			timeoutPromise
 		]);
 
-		return { address, reachable: true };
+		const client = new ReflectionClient({
+			endpoint: address,
+			tls: input.tlsEnabled ?? address.endsWith(':443'),
+			timeout: 3000,
+		});
+		try {
+			await client.probeReflection();
+			return { address, reachable: true, reflectionStatus: 'ready' };
+		} catch (error) {
+			const message = errorMessage(error);
+			return {
+				address,
+				reachable: false,
+				error: message,
+				reflectionStatus: classifyReflectionFailure(message),
+			};
+		} finally {
+			client.close();
+		}
 	} catch (error) {
 		const errorMsg = error instanceof Error ? error.message : 'Unknown error';
-		return { address, reachable: false, error: errorMsg };
+		return { address, reachable: false, error: errorMsg, reflectionStatus: 'transient' };
 	}
 }
 
 /**
  * POST /api/grpc/validate-endpoints
- * Validates multiple endpoints in parallel by checking DNS resolution
+ * Checks DNS first, then performs a bounded reflection handshake. DNS success
+ * alone is not enough to select a provider for Cosmos execution.
  *
  * Request body: { endpoints: string[] }
  * Response: { results: EndpointValidation[] }
@@ -67,7 +100,7 @@ async function validateEndpoint(address: string, timeoutMs: number = 1000): Prom
 export async function POST(request: Request) {
 	try {
 		const body = await request.json();
-		const { endpoints } = body as { endpoints: string[] };
+		const { endpoints } = body as { endpoints: Array<string | EndpointInput> };
 
 		if (!endpoints || !Array.isArray(endpoints)) {
 			return NextResponse.json(
@@ -76,10 +109,21 @@ export async function POST(request: Request) {
 			);
 		}
 
-		// Validate all endpoints concurrently with 1s timeout each (fast rejection)
-		const results = await Promise.all(
-			endpoints.map(ep => validateEndpoint(ep, 1000))
-		);
+		const normalized = endpoints.map((endpoint) =>
+			typeof endpoint === 'string' ? { address: endpoint } : endpoint
+		).filter((endpoint): endpoint is EndpointInput => typeof endpoint?.address === 'string');
+		const endpointsToQualify = normalized.slice(0, MAX_QUALIFIED_ENDPOINTS);
+		const skippedEndpoints = normalized.slice(MAX_QUALIFIED_ENDPOINTS);
+		const results: EndpointValidation[] = [];
+		for (let index = 0; index < endpointsToQualify.length; index += 3) {
+			results.push(...await Promise.all(endpointsToQualify.slice(index, index + 3).map((endpoint) => validateEndpoint(endpoint, 1000))));
+		}
+		results.push(...skippedEndpoints.map(({ address }) => ({
+			address,
+			reachable: false,
+			reflectionStatus: 'transient' as const,
+			error: `Qualification skipped after ${MAX_QUALIFIED_ENDPOINTS} endpoints; reselect manually to try this provider.`,
+		})));
 
 		const reachableCount = results.filter(r => r.reachable).length;
 		console.log(`[ValidateEndpoints] ${reachableCount}/${results.length} endpoints reachable`);

--- a/components/AddNetworkDialog.tsx
+++ b/components/AddNetworkDialog.tsx
@@ -264,17 +264,16 @@ const AddNetworkDialog: React.FC<AddNetworkDialogProps> = ({ onAdd, onClose, def
 		debug.log(`Selected cached chain: ${cached.chainId || cached.endpoint}`);
 	};
 
-	// Validate endpoints by checking DNS resolution
+	// Qualify endpoints with DNS and a bounded reflection handshake.
 	const validateEndpoints = async (configs: EndpointConfig[]): Promise<EndpointConfig[]> => {
 		if (configs.length === 0) return configs;
 
 		setValidatingEndpoints(true);
 		try {
-			const addresses = configs.map(c => c.address);
 			const response = await fetch('/api/grpc/validate-endpoints', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ endpoints: addresses })
+				body: JSON.stringify({ endpoints: configs.map(({ address, tlsEnabled }) => ({ address, tlsEnabled })) })
 			});
 
 			if (!response.ok) {
@@ -291,7 +290,8 @@ const AddNetworkDialog: React.FC<AddNetworkDialogProps> = ({ onAdd, onClose, def
 					...config,
 					reachable: validation?.reachable ?? undefined,
 					validationError: validation?.error,
-					// Auto-deselect unreachable endpoints
+					reflectionStatus: validation?.reflectionStatus,
+					// Do not start a network with providers that cannot serve reflection.
 					selected: validation?.reachable !== false ? config.selected : false
 				};
 			});

--- a/components/EndpointSelector.tsx
+++ b/components/EndpointSelector.tsx
@@ -98,17 +98,17 @@ const EndpointSelector: React.FC<EndpointSelectorProps> = ({
 	const allSelected = selectedCount === endpoints.length && endpoints.length > 0;
 	const someSelected = selectedCount > 0 && selectedCount < endpoints.length;
 
-	// Toggle all endpoints: if any selected → deselect all, if none → select all reachable
+	// Toggle all endpoints: if any selected → deselect all, if none → select qualified endpoints.
 	const handleSelectAll = useCallback(() => {
 		const anySelected = selectedCount > 0;
 		onChange(endpoints.map(ep => ({
 			...ep,
-			// Deselect all if any selected, otherwise select all reachable
+			// Deselect all if any selected, otherwise select all qualified endpoints.
 			selected: anySelected ? false : (ep.reachable !== false)
 		})));
 	}, [endpoints, selectedCount, onChange]);
 
-	// Select only reachable endpoints
+	// Select only endpoints that passed DNS plus reflection qualification.
 	const handleSelectReachable = useCallback(() => {
 		onChange(endpoints.map(ep => ({
 			...ep,
@@ -172,7 +172,7 @@ const EndpointSelector: React.FC<EndpointSelectorProps> = ({
 							onClick={handleSelectReachable}
 							className="text-xs text-primary hover:underline ml-2"
 						>
-							Select reachable only ({reachableCount})
+							Select qualified only ({reachableCount})
 						</button>
 					)}
 				</div>
@@ -263,7 +263,7 @@ const EndpointSelector: React.FC<EndpointSelectorProps> = ({
 			{/* Summary */}
 			{!validating && unreachableCount > 0 && (
 				<div className="text-xs text-amber-500 text-center pt-2">
-					{unreachableCount} endpoint{unreachableCount !== 1 ? 's' : ''} unreachable (DNS resolution failed)
+					{unreachableCount} endpoint{unreachableCount !== 1 ? 's are' : ' is'} not reflection-ready; you can reselect one to try it manually.
 				</div>
 			)}
 			{selectedCount === 0 && !validating && (

--- a/components/GrpcExplorerApp.tsx
+++ b/components/GrpcExplorerApp.tsx
@@ -18,6 +18,7 @@ import { GrpcNetwork, GrpcService, GrpcMethod, MethodInstance, ExecutionResult, 
 import { descriptorLoader } from '@/lib/utils/descriptor-loader';
 import { isServiceDescriptorReady, servicesNeedingDescriptors } from '@/lib/utils/descriptor-readiness';
 import { getExecutionEndpoints } from '@/lib/utils/execution-endpoints';
+import { classifyReflectionFailure } from '@/lib/utils/reflection-probe';
 import { toast } from 'sonner';
 
 // Color palette for networks
@@ -33,7 +34,34 @@ const NETWORK_COLORS = [
 ];
 
 // Keep persisted network state aligned with descriptor completeness metadata.
-const NETWORK_CACHE_VERSION = '2.0.0';
+const NETWORK_CACHE_VERSION = '2.1.0';
+const INCOMPATIBLE_ENDPOINT_COOLDOWN_MS = 60 * 60 * 1000;
+const TRANSIENT_ENDPOINT_COOLDOWN_MS = 60 * 1000;
+
+function updateExecutionHealth(
+  network: GrpcNetwork,
+  successfulEndpoint: string | undefined,
+  failures: Array<{ endpoint: string; error: string }>,
+  now: number
+): GrpcNetwork {
+  const endpointHealth = { ...network.endpointHealth };
+
+  for (const failure of failures) {
+    const reflectionFailure = failure.error.includes('Reflection initialization failed:');
+    const kind = reflectionFailure ? classifyReflectionFailure(failure.error) : 'transient';
+    endpointHealth[failure.endpoint] = {
+      ...endpointHealth[failure.endpoint],
+      lastErrorKind: kind,
+      retryAfter: now + (kind === 'incompatible' ? INCOMPATIBLE_ENDPOINT_COOLDOWN_MS : TRANSIENT_ENDPOINT_COOLDOWN_MS),
+    };
+  }
+
+  if (successfulEndpoint) {
+    endpointHealth[successfulEndpoint] = { lastSuccess: now };
+  }
+
+  return { ...network, endpointHealth };
+}
 
 export default function GrpcExplorerApp() {
   const [networks, setNetworks] = useState<GrpcNetwork[]>([]);
@@ -516,6 +544,7 @@ export default function GrpcExplorerApp() {
               endpoint: actualEndpoint,
               tlsEnabled: resolvedTls,
               endpoints: availableEndpoints.filter((ep: string) => ep !== actualEndpoint), // Store others as fallbacks
+              endpointHealth: { [actualEndpoint]: { lastSuccess: now } },
               ...(fetchedChainId ? { chainId: fetchedChainId } : {}),
               loading: false,
               cached: false,
@@ -628,6 +657,7 @@ export default function GrpcExplorerApp() {
             services: data.services || [],
             endpoint: actualEndpoint,
             chainId,
+            endpointHealth: { ...n.endpointHealth, [actualEndpoint]: { lastSuccess: now } },
             loading: false,
             cached: false,
             cacheTimestamp: now
@@ -945,6 +975,14 @@ export default function GrpcExplorerApp() {
 
       const data = await response.json();
       const duration = Date.now() - startTime;
+      const failedEndpoints = Array.isArray(data.failedEndpoints) ? data.failedEndpoints : [];
+      const usedEndpoint = typeof data.endpoint === 'string' ? data.endpoint : undefined;
+
+      setNetworks(prev => prev.map(network =>
+        network.id === instance.networkId
+          ? updateExecutionHealth(network, response.ok ? usedEndpoint : undefined, failedEndpoints, Date.now())
+          : network
+      ));
 
       const result: ExecutionResult = {
         methodId: instance.id,
@@ -953,7 +991,7 @@ export default function GrpcExplorerApp() {
         error: data.error,
         timestamp: Date.now(),
         duration,
-        endpoint: data.endpoint || selectedEndpoint
+        endpoint: usedEndpoint || selectedEndpoint
       };
 
       // Show every failed endpoint when a network-aware execution exhausts its fallbacks.

--- a/components/HelpDialog.tsx
+++ b/components/HelpDialog.tsx
@@ -152,7 +152,7 @@ const HelpDialog: React.FC<HelpDialogProps> = ({ open, onClose }) => {
                   </li>
                   <li className="flex items-start gap-2">
                     <ChevronRight className="h-4 w-4 mt-0.5 flex-shrink-0" />
-                    <span>Unreachable endpoints are deselected during validation before use.</span>
+                    <span>Endpoints that fail DNS or reflection qualification are deselected, but can be manually reselected.</span>
                   </li>
                 </ul>
               </div>

--- a/lib/grpc/reflection-client.ts
+++ b/lib/grpc/reflection-client.ts
@@ -617,6 +617,15 @@ export class ReflectionClient {
   }
 
   /**
+   * Verify that the endpoint accepts either supported reflection protocol without
+   * loading every protobuf descriptor. Used when qualifying Cosmos providers.
+   */
+  async probeReflection(): Promise<void> {
+    await this.initializeReflectionStub();
+    await this.listServices();
+  }
+
+  /**
    * List all available services
    */
   private async listServices(): Promise<string[]> {

--- a/lib/types/grpc.ts
+++ b/lib/types/grpc.ts
@@ -64,8 +64,16 @@ export interface EndpointConfig {
   tlsEnabled: boolean;
   selected: boolean;
   provider?: string;
-  reachable?: boolean; // DNS validation result (undefined = not checked yet)
-  validationError?: string; // Error message if validation failed
+  reachable?: boolean; // Reflection qualification result (undefined = not checked yet)
+  validationError?: string; // DNS or reflection qualification error
+  reflectionStatus?: 'ready' | 'incompatible' | 'transient';
+}
+
+/** Client-persisted execution result used to avoid repeatedly starting with known-bad providers. */
+export interface EndpointExecutionHealth {
+  lastSuccess?: number;
+  retryAfter?: number;
+  lastErrorKind?: 'incompatible' | 'transient';
 }
 
 export interface GrpcNetwork {
@@ -74,6 +82,7 @@ export interface GrpcNetwork {
   endpoint: string;
   endpoints?: string[]; // Additional fallback endpoints for this chain (legacy)
   endpointConfigs?: EndpointConfig[]; // Per-endpoint settings for round-robin
+  endpointHealth?: Record<string, EndpointExecutionHealth>;
   chainId?: string;
   tlsEnabled: boolean;
   services: GrpcService[];

--- a/lib/utils/execution-endpoints.ts
+++ b/lib/utils/execution-endpoints.ts
@@ -1,4 +1,4 @@
-import type { GrpcNetwork } from '@/lib/types/grpc';
+import type { EndpointExecutionHealth, GrpcNetwork } from '@/lib/types/grpc';
 import { errorMessage } from '@/lib/utils';
 
 export type ExecutionEndpoint = {
@@ -12,10 +12,17 @@ export type EndpointExecutionFailure = {
 };
 
 export class EndpointFailoverError extends Error {
-  constructor(public readonly failures: EndpointExecutionFailure[]) {
-    super(`All selected gRPC endpoints failed: ${failures.map(({ endpoint, error }) => `${endpoint}: ${error}`).join('; ')}`);
+  constructor(public readonly failures: EndpointExecutionFailure[], deadlineExhausted: boolean = false) {
+    super(`${deadlineExhausted ? 'gRPC endpoint execution deadline exhausted' : 'All selected gRPC endpoints failed'}: ${failures.map(({ endpoint, error }) => `${endpoint}: ${error}`).join('; ')}`);
     this.name = 'EndpointFailoverError';
   }
+}
+
+export const INCOMPATIBLE_ENDPOINT_COOLDOWN_MS = 60 * 60 * 1000;
+export const TRANSIENT_ENDPOINT_COOLDOWN_MS = 60 * 1000;
+
+function isEligible(address: string, health: Record<string, EndpointExecutionHealth> | undefined, now: number): boolean {
+  return !health?.[address]?.retryAfter || health[address].retryAfter <= now;
 }
 
 /**
@@ -23,7 +30,7 @@ export class EndpointFailoverError extends Error {
  * Cosmos sources rotate selected endpoints, then retain the rest as failover
  * candidates so networks with mixed SDK/provider availability stay usable.
  */
-export function getExecutionEndpoints(network: GrpcNetwork, startIndex: number): ExecutionEndpoint[] {
+export function getExecutionEndpoints(network: GrpcNetwork, startIndex: number, now: number = Date.now()): ExecutionEndpoint[] {
   if (network.mode !== 'cosmos') {
     return [{ address: network.endpoint, tlsEnabled: network.tlsEnabled }];
   }
@@ -34,24 +41,47 @@ export function getExecutionEndpoints(network: GrpcNetwork, startIndex: number):
   }
 
   const normalizedStart = ((startIndex % selected.length) + selected.length) % selected.length;
-  return [...selected.slice(normalizedStart), ...selected.slice(0, normalizedStart)].map(
+  const rotated = [...selected.slice(normalizedStart), ...selected.slice(0, normalizedStart)].map(
     ({ address, tlsEnabled }) => ({ address, tlsEnabled })
   );
+  const candidates = rotated.some((endpoint) => endpoint.address === network.endpoint)
+    ? rotated
+    : [...rotated, { address: network.endpoint, tlsEnabled: network.tlsEnabled }];
+  const eligible = candidates.filter((endpoint) => isEligible(endpoint.address, network.endpointHealth, now));
+  const usable = eligible.length > 0 ? eligible : candidates;
+
+  return usable;
 }
+
+export type FailoverOptions = {
+  deadlineAt?: number;
+  now?: () => number;
+  shouldFailover?: (error: unknown, endpoint: ExecutionEndpoint) => boolean;
+};
 
 export async function executeWithEndpointFailover<T>(
   endpoints: ExecutionEndpoint[],
-  execute: (endpoint: ExecutionEndpoint) => Promise<T>
+  execute: (endpoint: ExecutionEndpoint) => Promise<T>,
+  options: FailoverOptions = {}
 ): Promise<{ value: T; endpoint: ExecutionEndpoint; failures: EndpointExecutionFailure[] }> {
   const failures: EndpointExecutionFailure[] = [];
+  const now = options.now ?? Date.now;
+  let deadlineExhausted = false;
 
   for (const endpoint of endpoints) {
+    if (options.deadlineAt !== undefined && now() >= options.deadlineAt) {
+      deadlineExhausted = true;
+      break;
+    }
     try {
       return { value: await execute(endpoint), endpoint, failures };
     } catch (error) {
+      if (options.shouldFailover && !options.shouldFailover(error, endpoint)) {
+        throw error;
+      }
       failures.push({ endpoint: endpoint.address, error: errorMessage(error) });
     }
   }
 
-  throw new EndpointFailoverError(failures);
+  throw new EndpointFailoverError(failures, deadlineExhausted);
 }

--- a/lib/utils/reflection-probe.ts
+++ b/lib/utils/reflection-probe.ts
@@ -1,0 +1,11 @@
+export type ReflectionFailureKind = 'incompatible' | 'transient';
+
+export function classifyReflectionFailure(message: string): ReflectionFailureKind {
+  const normalized = message.toLowerCase();
+  return normalized.includes('permission_denied') ||
+    normalized.includes('http status code 403') ||
+    normalized.includes('unimplemented') ||
+    normalized.includes('http status code 404')
+    ? 'incompatible'
+    : 'transient';
+}

--- a/tests/execution-endpoints.test.ts
+++ b/tests/execution-endpoints.test.ts
@@ -39,6 +39,21 @@ describe('execution endpoint selection', () => {
 		]);
 	});
 
+	it('keeps selected Cosmos endpoints in round-robin order before a successful discovery fallback', () => {
+		const network: GrpcNetwork = {
+			...cosmosNetwork,
+			endpoint: 'discovered:443',
+			endpointHealth: { 'discovered:443': { lastSuccess: Date.now() } },
+		};
+
+		expect(getExecutionEndpoints(network, 1).map((endpoint) => endpoint.address)).toEqual([
+			'secondary:443',
+			'tertiary:9090',
+			'primary:443',
+			'discovered:443',
+		]);
+	});
+
 	it('continues to the next selected endpoint after a connection failure', async () => {
 		const attempts: string[] = [];
 		const result = await executeWithEndpointFailover(
@@ -58,5 +73,86 @@ describe('execution endpoint selection', () => {
 			endpoint: { address: 'secondary:443', tlsEnabled: true },
 			failures: [{ endpoint: 'primary:443', error: 'connect ETIMEDOUT primary:443' }],
 		});
+	});
+
+	it('prefers the successful discovery endpoint and skips endpoints on cooldown', () => {
+		const now = 1_000_000;
+		const network: GrpcNetwork = {
+			...cosmosNetwork,
+			endpoint: 'discovered:443',
+			endpointConfigs: [
+				{ address: 'denied:443', tlsEnabled: true, selected: true },
+				{ address: 'timed-out:443', tlsEnabled: true, selected: true },
+			],
+			endpointHealth: {
+				'discovered:443': { lastSuccess: now - 1_000 },
+				'denied:443': { retryAfter: now + 60_000, lastErrorKind: 'incompatible' },
+				'timed-out:443': { retryAfter: now + 10_000, lastErrorKind: 'transient' },
+			},
+		};
+
+		expect(getExecutionEndpoints(network, 0, now)).toEqual([
+			{ address: 'discovered:443', tlsEnabled: true },
+		]);
+	});
+
+	it('uses a cooled-down endpoint only when there is no eligible alternative', () => {
+		const now = 1_000_000;
+		const network: GrpcNetwork = {
+			...cosmosNetwork,
+			endpoint: 'only:443',
+			endpointConfigs: [{ address: 'only:443', tlsEnabled: true, selected: true }],
+			endpointHealth: {
+				'only:443': { retryAfter: now + 60_000, lastErrorKind: 'incompatible' },
+			},
+		};
+
+		expect(getExecutionEndpoints(network, 0, now)).toEqual([
+			{ address: 'only:443', tlsEnabled: true },
+		]);
+	});
+
+	it('stops retrying when the request-wide deadline is exhausted', async () => {
+		const attempts: string[] = [];
+		let now = 0;
+
+		await expect(executeWithEndpointFailover(
+			[
+				{ address: 'first:443', tlsEnabled: true },
+				{ address: 'second:443', tlsEnabled: true },
+			],
+			async (endpoint) => {
+				attempts.push(endpoint.address);
+				now = 10;
+				throw new Error('connection failed');
+			},
+			{ deadlineAt: 10, now: () => now }
+		)).rejects.toMatchObject({
+			failures: [{ endpoint: 'first:443', error: 'connection failed' }],
+		});
+		await expect(executeWithEndpointFailover(
+			[{ address: 'first:443', tlsEnabled: true }],
+			async () => { throw new Error('connection failed'); },
+			{ deadlineAt: 0, now: () => 0 }
+		)).rejects.toThrow('execution deadline exhausted');
+
+		expect(attempts).toEqual(['first:443']);
+	});
+
+	it('does not fail over a method-level error when the caller marks it unsafe to retry', async () => {
+		const attempts: string[] = [];
+		await expect(executeWithEndpointFailover(
+			[
+				{ address: 'first:443', tlsEnabled: true },
+				{ address: 'second:443', tlsEnabled: true },
+			],
+			async (endpoint) => {
+				attempts.push(endpoint.address);
+				throw new Error('Method invocation failed: 3 INVALID_ARGUMENT');
+			},
+			{ shouldFailover: () => false }
+		)).rejects.toThrow('Method invocation failed: 3 INVALID_ARGUMENT');
+
+		expect(attempts).toEqual(['first:443']);
 	});
 });

--- a/tests/reflection-probe.test.ts
+++ b/tests/reflection-probe.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { classifyReflectionFailure } from '@/lib/utils/reflection-probe';
+
+describe('reflection probe failures', () => {
+	it('classifies denied and unimplemented reflection as incompatible', () => {
+		expect(classifyReflectionFailure('7 PERMISSION_DENIED: Received HTTP status code 403')).toBe('incompatible');
+		expect(classifyReflectionFailure('12 UNIMPLEMENTED: Received HTTP status code 404')).toBe('incompatible');
+	});
+
+	it('classifies connection timeouts as transient', () => {
+		expect(classifyReflectionFailure('14 UNAVAILABLE: connect ETIMEDOUT 167.235.196.205:8443')).toBe('transient');
+	});
+});


### PR DESCRIPTION
## Summary
- qualify Cosmos providers with a bounded v1/v1alpha reflection handshake after DNS
- keep selected endpoint round-robin intact while skipping cooldown endpoints and retaining the successful discovery endpoint as fallback
- bound reflection failover by a request-wide deadline and never retry semantic method failures across providers

## Root cause
DNS-only validation accepted endpoints that either denied reflection, served HTTP 404, or timed out. Execution then truncated fallback candidates before reaching the discovered reflection-capable endpoint.

## Validation
- yarn test (127 tests)
- yarn lint (existing debug-console warnings only)
- yarn build:prod
- cross-directory review completed and findings addressed